### PR TITLE
NVCF-2262: Improve error message with API response error details

### DIFF
--- a/internal/provider/utils/nvcf_client.go
+++ b/internal/provider/utils/nvcf_client.go
@@ -43,12 +43,14 @@ func (c *NVCFClient) HTTPClient(context.Context) *http.Client {
 	return c.HttpClient
 }
 
+type RequestStatusModel struct {
+	StatusCode        string `json:"statusCode"`
+	StatusDescription string `json:"statusDescription"`
+	RequestID         string `json:"requestId"`
+}
+
 type ErrorResponse struct {
-	Type     string `json:"type"`
-	Title    string `json:"title"`
-	Status   int    `json:"status"`
-	Detail   string `json:"detail"`
-	Instance string `json:"instance"`
+	RequestStatus RequestStatusModel `json:"requestStatus"`
 }
 
 func (c *NVCFClient) sendRequest(ctx context.Context, requestURL string, method string, requestBody any, responseObject any, expectedStatusCode map[int]bool) error {
@@ -101,9 +103,9 @@ func (c *NVCFClient) sendRequest(ctx context.Context, requestURL string, method 
 		if err != nil {
 			ctx = tflog.SetField(ctx, "response_body", string(body))
 			tflog.Error(ctx, "failed to parse error response body")
-			return err
+			return fmt.Errorf("failed to parse error response body. Response body: %s", string(body))
 		}
-		return errors.New(errResponseObject.Detail)
+		return errors.New(errResponseObject.RequestStatus.StatusDescription)
 	}
 
 	if responseObject != nil {

--- a/internal/provider/utils/nvcf_client_test.go
+++ b/internal/provider/utils/nvcf_client_test.go
@@ -140,15 +140,15 @@ var mockFunctionDeploymentActiveInfo = fmt.Sprintf(
 	mockDeploymentSpecification,
 )
 
-var mockErrorDetail = "Validation failure"
+var mockErrorDetail = "Validation failed - [All allocated GPU instances in use - contact your support team]"
 var mockErrorResponse = fmt.Sprintf(
 	`
 	{
-	"type": "about:blank",
-	"title": "Bad Request",
-	"status": 400,
-	"detail": "%s",
-	"instance": "/v2/nvcf/accounts/2Q-6YGjFk5wg59_WCMW9x0zJyrYOkTeRdKbQIpYyXFo/deployments/functions/985cc4d8-0d14-4a97-953e-ef51977d4945/versions/88f8c7d3-8d94-4c59-8d56-4bd02fbad6ba"
+		"requestStatus": {
+			"statusCode": "INVALID_REQUEST",
+			"statusDescription": "%s",
+			"requestId": "a3023cc6-2705972"
+		}
 	}
 	`,
 	mockErrorDetail,
@@ -419,7 +419,7 @@ func TestNVCFClient_CreateNvidiaCloudFunction(t *testing.T) {
 						nvcfRequestHeaders,
 						createContainerBasedNvidiaCloudFunctionReq,
 						mockErrorResponse,
-						500,
+						400,
 					),
 				},
 			},


### PR DESCRIPTION
After updating, the error message will show as below.

```
(base) ➜  ngc-terraform-provider-test terraform apply "local.tfplan"   
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - nvidia.com/dev/ngc in /home/huaweic/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
ngc_cloud_function.helm_based_cloud_function_example_empty: Creating...
ngc_cloud_function.helm_based_cloud_function_example: Creating...
ngc_cloud_function.model_based_cloud_function_example: Creating...
ngc_cloud_function.helm_based_cloud_function_example_empty: Creation complete after 1s [id=43d54d17-e309-4306-9a0b-e04784ea05a1]
ngc_cloud_function.model_based_cloud_function_example: Creation complete after 2s [id=a205136c-9632-46bc-a5d6-fbc596bfca22]
data.ngc_cloud_function.terraform-cloud-function-datasource-example: Reading...
data.ngc_cloud_function.terraform-cloud-function-datasource-example: Read complete after 0s
╷
│ Error: Failed to create Cloud Function Deployment
│ 
│   with ngc_cloud_function.helm_based_cloud_function_example,
│   on ngc-terraform-test.tf line 147, in resource "ngc_cloud_function" "helm_based_cloud_function_example":
│  147: resource "ngc_cloud_function" "helm_based_cloud_function_example" {
│ 
│ Validation failed - [All allocated GPU instances in use - contact your support team]
```