### PR TITLE
fix: remove compromised Trivy scan from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ permissions:
   contents: read
   pull-requests: write
   checks: write           # Required for dorny/test-reporter
-  security-events: write  # Required for SARIF upload
 
 jobs:
   # =============================================================================
@@ -139,30 +138,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: build-artifacts
-          path: dist/
-
-      - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          vuln-type: 'os,library'
-          severity: 'HIGH,CRITICAL'
-          ignore-unfixed: true
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          skip-dirs: 'vendor,node_modules,dist'
-
-      - name: Upload Trivy SARIF report
-        uses: github/codeql-action/upload-sarif@v4.32.6
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
 
       - name: Run TruffleHog secret scan
         uses: trufflesecurity/trufflehog@v3.93.7


### PR DESCRIPTION
## Summary

Trivy (`aquasecurity/trivy-action@0.35.0`) has been reported as compromised. This PR removes the Trivy vulnerability scan and related steps from the `security-scan` job in the CI workflow.

### Changes
- Removed `Run Trivy vulnerability scan` step (`aquasecurity/trivy-action@0.35.0`)
- Removed `Upload Trivy SARIF report` step (`github/codeql-action/upload-sarif@v4.32.6`)
- Removed `Download build artifacts` step (only needed for Trivy fs scan)
- Removed `security-events: write` permission (only needed for SARIF upload)
- Retained `Run TruffleHog secret scan` step (unaffected)

### Context
Automated audit scanned 691 repos across `cds`, `nvb`, `nvcf`, `ncp` groups on gitlab-master. This repo is the **only** one with active CI usage of Trivy. Full report in [CDEVS-2134](https://jirasw.nvidia.com/browse/CDEVS-2134).

